### PR TITLE
Quick and dirty temporary solution for #43

### DIFF
--- a/app/src/main/java/org/indywidualni/fblite/webview/MyAppWebViewClient.java
+++ b/app/src/main/java/org/indywidualni/fblite/webview/MyAppWebViewClient.java
@@ -40,6 +40,7 @@ public class MyAppWebViewClient extends WebViewClient {
                 || Uri.parse(url).getHost().endsWith("l.facebook.com")
                 || Uri.parse(url).getHost().endsWith("0.facebook.com")
                 || Uri.parse(url).getHost().endsWith("zero.facebook.com")
+                || Uri.parse(url).getHost().endsWith("fbcdn.net")
                 || Uri.parse(url).getHost().endsWith("fb.me")) {
             return false;
         }

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -119,6 +119,8 @@
     <string name="crash_dialog_comment_prompt">Ваш коментар о проблему можете да додате испод:</string>
     <string name="file_logger">Сачувај запис у фајл</string>
     <string name="file_logger_description">Упис записа сервиса обавештавања у спољашње складиште. Захтева дозволе за складиште.</string>
-    <string name="file_logger_needs_permission">Немам приступ спољашњем складишту. Не могу да сачувам записе.</string>
+    <string name="file_logger_needs_permission">Немам приступ спољашњем складишту. Не могу да сачувам записе</string>
+    <string name="save_img">Сачувај слику</string>
+    <string name="downloading_img">Преузимам слику&#8230;</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,5 +128,7 @@
     <string name="file_logger">Save logs to a file</string>
     <string name="file_logger_description">Save Notification Service logs to an external memory. It needs a storage permission.</string>
     <string name="file_logger_needs_permission">No access to external storage. Log cannot be saved</string>
+    <string name="save_img">Save image</string>
+    <string name="downloading_img">Downloading image&#8230;</string>
 
 </resources>


### PR DESCRIPTION
Heavily based on parts of the "Tinfoil for Facebook" code. I know its ugly and not optimal, but it works for a use case when a user wants to open the picture to view ("Show in full size" link) it and download it (long tap and select "Save image"). This:
```
+        webView.getSettings().setSupportZoom(true);
+        webView.getSettings().setBuiltInZoomControls(true);
+        webView.getSettings().setUseWideViewPort(true);
```
is needed to be able to zoom out the opened picture (but you can ommit `webView.getSettings().setBuiltInZoomControls(true);`). It has a very interesting consequence, now you can pinch-zoom if you are using basic facebook site (#56).

Compiled apk for testing: [signed](https://freeshell.de/~pejakm/preuzimanja/FaceSlim-test43-signed.apk) and [unsigned](https://freeshell.de/~pejakm/preuzimanja/FaceSlim-test43-unsigned.apk).

References #43 