### PR TITLE
Option to allow loading external images from common image sharing websites

### DIFF
--- a/app/src/main/java/org/indywidualni/fblite/activity/MainActivity.java
+++ b/app/src/main/java/org/indywidualni/fblite/activity/MainActivity.java
@@ -103,6 +103,7 @@ public class MainActivity extends Activity {
     private static final int ID_CONTEXT_MENU_SAVE_IMAGE = 2562617;
     private String mPendingImageUrlToSave = null;
     private static String appDirectoryName;
+    private String imgExt = null;
 
     // user agents
     private static String USER_AGENT_DEFAULT;
@@ -951,8 +952,25 @@ public class MainActivity extends Activity {
                 imageStorageDir.mkdirs();
             }
 
+            if (imageUrl.contains(".jpg") || imageUrl.contains(".jpeg")) {
+                Log.w(TAG, "Image is jpg or jpeg");
+                imgExt = ".jpg";
+            }
+            else if (imageUrl.contains(".gif")) {
+                Log.w(TAG, "Image is gif");
+                imgExt = ".gif";
+            }
+            else if (imageUrl.contains(".png")) {
+                Log.w(TAG, "Image is png");
+                imgExt = ".png";
+            }
+            else {
+                Log.w(TAG, "Image is other, defaulting to jpg");
+                imgExt = ".jpg";
+            }
+
             String date = DateFormat.getDateTimeInstance().format(new Date());
-            String file = "IMG_" + date.replace(" ", "-") + ".jpg";
+            String file = "IMG_" + date.replace(" ", "-") + imgExt;
 
             DownloadManager dm = (DownloadManager) this.getSystemService(Context.DOWNLOAD_SERVICE);
             Uri downloadUri = Uri.parse(imageUrl);

--- a/app/src/main/java/org/indywidualni/fblite/webview/MyWebViewClient.java
+++ b/app/src/main/java/org/indywidualni/fblite/webview/MyWebViewClient.java
@@ -45,6 +45,13 @@ public class MyWebViewClient extends WebViewClient {
                 || Uri.parse(url).getHost().endsWith("fb.me")) {
             return false;
         }
+        else if (preferences.getBoolean("load_extra", true)
+                && (Uri.parse(url).getHost().endsWith("googleusercontent.com")
+                || Uri.parse(url).getHost().endsWith("tumblr.com")
+                || Uri.parse(url).getHost().endsWith("pinimg.com")
+                || Uri.parse(url).getHost().endsWith("media.giphy.com"))) {
+            return false;
+        }
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         view.getContext().startActivity(intent);
         return true;

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -49,6 +49,8 @@
     <string name="facebook_zero">Фејсбук Зиро</string>
     <string name="facebook_zero_description">Без надокнаде за пренесене податке. Зависи од вашег оператера. Ради при вези мобилних података.</string>
     <string name="facebook_zero_active">Фејсбук Зиро је активан</string>
+    <string name="load_extra">Учитавај спољашње слике</string>
+    <string name="load_extra_description">Учитавање слика са других сајтова унутар апликације. Тренутно подржано само пар сајтова.</string>
     <string name="preference_category4">Додатно</string>
     <string name="quick_guide">Водич за брзи почетак</string>
     <string name="messages">Поруке</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="facebook_zero">Facebook Zero</string>
     <string name="facebook_zero_description">No data charges. GSM provider dependent. Works during mobile network connection.</string>
     <string name="facebook_zero_active">Facebook Zero is active</string>
+    <string name="load_extra">Load external pictures</string>
+    <string name="load_extra_description">Open external pictures in-app. Currently only few sites are supported.</string>
     <string name="preference_category4">Additional</string>
     <string name="quick_guide">Quick Start Guide</string>
     <string name="messages">Messages</string>

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -112,6 +112,12 @@
             android:summary="@string/hide_news_feed_description"
             android:defaultValue="false"/>
         
+        <CheckBoxPreference
+            android:key="load_extra"
+            android:title="@string/load_extra"
+            android:summary="@string/load_extra_description"
+            android:defaultValue="false"/>
+        
     </PreferenceCategory>
 
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -112,6 +112,12 @@
             android:summary="@string/hide_news_feed_description"
             android:defaultValue="false"/>
         
+        <CheckBoxPreference
+            android:key="load_extra"
+            android:title="@string/load_extra"
+            android:summary="@string/load_extra_description"
+            android:defaultValue="false"/>
+        
         </PreferenceCategory>
 
 


### PR DESCRIPTION
Just a "proof of concept". I'm using it 'cause I really like to open an image and be able to save it, directly from FaceSlim. For now, I've included these servers:

 * googleusercontent.com
 * tumblr.com
 * pinimg.com
 * media.giphy.com

because those are that my contacts and pages I follow mostly use.