### PR TITLE
Added option to use Tor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:support-v4:24.1.1'
-    compile 'com.android.support:appcompat-v7:24.1.1'
+    compile 'com.android.support:support-v4:24.2.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'org.jsoup:jsoup:1.9.2'
     compile 'ch.acra:acra:4.9.0'
     compile 'com.github.johnkil.android-appmsg:appmsg:1.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "24.0.1"
 
     defaultConfig {
-        applicationId "org.indywidualni.fblite"
+        applicationId "org.indywidualni.fblite.debug"
         minSdkVersion 15
         targetSdkVersion 24
         versionCode 43
@@ -30,4 +30,5 @@ dependencies {
     compile 'org.jsoup:jsoup:1.9.2'
     compile 'ch.acra:acra:4.9.0'
     compile 'com.github.johnkil.android-appmsg:appmsg:1.2.0'
+    compile 'info.guardianproject.netcipher:netcipher:1.2.1'
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,3 +13,7 @@
 
 # jsoup library
 -keeppackagenames org.jsoup.nodes
+
+# StrongHttpsClient and its support classes are totally unused, so the
+# ch.boye.httpclientandroidlib.** classes are also unneeded
+-dontwarn info.guardianproject.netcipher.client.*

--- a/app/src/main/java/org/indywidualni/fblite/activity/MainActivity.java
+++ b/app/src/main/java/org/indywidualni/fblite/activity/MainActivity.java
@@ -66,6 +66,8 @@ import java.lang.ref.WeakReference;
 import java.text.DateFormat;
 import java.util.Date;
 
+import info.guardianproject.netcipher.web.WebkitProxy;
+
 @SuppressWarnings("UnusedDeclaration")
 public class MainActivity extends Activity {
 
@@ -249,6 +251,15 @@ public class MainActivity extends Activity {
             if (Build.VERSION.SDK_INT < 24) {
                 //noinspection deprecation
                 webView.getSettings().setGeolocationDatabasePath(getFilesDir().getPath());
+            }
+        }
+
+        // Tor proxy
+        if (preferences.getBoolean("use_tor", false)) {
+            try {
+                WebkitProxy.setProxy("org.indywidualni.fblite.MyApplication", getApplicationContext(), webView, "localhost", 8118);
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to set webview proxy", e);
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,5 +166,7 @@
     <string name="confirm_exit">Confirm exiting the app</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="use_tor_title">Use Tor &#8635;</string>
+    <string name="use_tor_summary">Force all traffic through Tor for increased privacy. Requires Orbot.</string>
 
 </resources>

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -115,6 +115,12 @@
             android:defaultValue="false"/>
 
         <SwitchPreference
+            android:key="use_tor"
+            android:title="@string/use_tor_title"
+            android:summary="@string/use_tor_summary"
+            android:defaultValue="false"/>
+
+        <SwitchPreference
             android:key="app_updates"
             android:title="@string/check_for_updates"
             android:defaultValue="true"/>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -115,6 +115,12 @@
             android:defaultValue="false"/>
 
         <CheckBoxPreference
+            android:key="use_tor"
+            android:title="@string/use_tor_title"
+            android:summary="@string/use_tor_summary"
+            android:defaultValue="false"/>
+
+        <CheckBoxPreference
             android:key="app_updates"
             android:title="@string/check_for_updates"
             android:defaultValue="true"/>


### PR DESCRIPTION
This adds an option which tunnels all webview requests through Tor. Requires the Orbot app to be installed and running. Note that notifications aren't going through Tor yet (but I will add that later if you like this PR).

To test this, I installed Orbot, enabled Tor in FaceSlim, and blocked all FaceSlim traffic via AFWall+ (result: app still worked correctly as traffic was routed through Orbot).

I also wanted to use Facebook's .onion URL, but this didn't work in my tests (probably because the DNS requests aren't proxied for some reason).