### PR TITLE
Fix Tor integration (fixes #229)

### DIFF
--- a/app/src/main/java/org/indywidualni/fblite/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/indywidualni/fblite/fragment/SettingsFragment.java
@@ -20,6 +20,7 @@ import org.indywidualni.fblite.R;
 import org.indywidualni.fblite.activity.MainActivity;
 import org.indywidualni.fblite.service.NotificationsService;
 import org.indywidualni.fblite.util.FileOperation;
+import org.indywidualni.fblite.util.Miscellany;
 
 public class SettingsFragment extends PreferenceFragment implements Preference.OnPreferenceClickListener {
 
@@ -122,6 +123,7 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
                     case "keyboard_fix":
                     case "hardware_acceleration":
                     case "custom_user_agent":
+                    case "use_tor":
                         relaunch();
                         break;
                 }
@@ -162,6 +164,13 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
         super.onResume();
         // register the listener
         preferences.registerOnSharedPreferenceChangeListener(prefChangeListener);
+        // update tor (proxy) info
+        try {
+            findPreference("use_tor").setSummary(getString(R.string.use_tor_summary) + " ― Proxy: " +
+                    Miscellany.getProxy(preferences).toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/indywidualni/fblite/service/NotificationsService.java
+++ b/app/src/main/java/org/indywidualni/fblite/service/NotificationsService.java
@@ -194,6 +194,7 @@ public class NotificationsService extends Service {
             try {
                 return Jsoup.connect(connectUrl)
                         .userAgent(userAgent).timeout(JSOUP_TIMEOUT)
+                        .proxy(Miscellany.getProxy(preferences))
                         .cookie("https://mobile.facebook.com", CookieManager.getInstance().getCookie("https://mobile.facebook.com"))
                         .get()
                         .select("div.touchable-notification")
@@ -282,6 +283,7 @@ public class NotificationsService extends Service {
             try {
                 Elements message = Jsoup.connect(connectUrl)
                         .userAgent(userAgent)
+                        .proxy(Miscellany.getProxy(preferences))
                         .timeout(JSOUP_TIMEOUT)
                         .cookie("https://m.facebook.com", CookieManager.getInstance().getCookie("https://m.facebook.com"))
                         .get()

--- a/app/src/main/java/org/indywidualni/fblite/util/CheckUpdatesTask.java
+++ b/app/src/main/java/org/indywidualni/fblite/util/CheckUpdatesTask.java
@@ -86,7 +86,7 @@ public class CheckUpdatesTask extends AsyncTask<Void, Void, String> {
             
         try {
             URL url = new URL(myUrl);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection(Miscellany.getProxy(preferences));
             conn.setReadTimeout(10000 /* milliseconds */);
             conn.setConnectTimeout(15000 /* milliseconds */);
             conn.setRequestMethod("GET");

--- a/app/src/main/java/org/indywidualni/fblite/util/Miscellany.java
+++ b/app/src/main/java/org/indywidualni/fblite/util/Miscellany.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
@@ -14,6 +15,8 @@ import android.util.Log;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -76,6 +79,16 @@ public class Miscellany {
         sb.append("\nLocale: ").append(Locale.getDefault().toString());
 
         return sb.toString();
+    }
+
+    /**
+     * Returns a Tor proxy if the option is enabled, or no proxy.
+     */
+    public static Proxy getProxy(SharedPreferences preferences) {
+        boolean useTor = preferences.getBoolean("use_tor", false);
+        return (useTor)
+                ? new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118))
+                : Proxy.NO_PROXY;
     }
 
     public static void copyTextToClipboard(Context context, String label, String text) {

--- a/app/src/main/java/org/indywidualni/fblite/util/Offline.java
+++ b/app/src/main/java/org/indywidualni/fblite/util/Offline.java
@@ -62,6 +62,7 @@ public class Offline {
             try {
                 final Document response = Jsoup.connect(args[0])
                         .userAgent(userAgent)
+                        .proxy(Miscellany.getProxy(preferences))
                         .header("Accept-Encoding", "gzip, deflate")
                         .timeout(5000)
                         .cookie("https://m.facebook.com", CookieManager.getInstance().getCookie("https://m.facebook.com"))

--- a/app/src/main/java/org/indywidualni/fblite/util/WebViewProxyUtil.java
+++ b/app/src/main/java/org/indywidualni/fblite/util/WebViewProxyUtil.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2013 Daniel Velazco
+ * Copyright (C) 2016 Jeff Gehlbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.indywidualni.fblite.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Proxy;
+import android.os.Build;
+import android.os.Parcelable;
+import android.util.ArrayMap;
+import android.util.Log;
+import android.webkit.WebView;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Taken from
+ * https://github.com/velazcod/Tinfoil-Facebook/blob/8850f06/app/src/main/java/com/danvelazco/fbwrapper/util/WebViewProxyUtil.java
+ */
+public class WebViewProxyUtil {
+
+    // Constants
+    private static final String LOG_TAG = "WebViewProxyUtil";
+
+    /**
+     * Helper method to set the proxy to a {@link android.webkit.WebView}
+     *
+     * @param context {@link Context}
+     * @param webview {@link android.webkit.WebView}
+     * @param host {@link String}
+     * @param port {@link int}
+     *
+     * @return {@link boolean}
+     */
+    public static boolean setProxy(Context context, WebView webview, String host, int port) {
+        // ICS: 4.0.3
+        if (Build.VERSION.SDK_INT <= 15) {
+            return setProxyICS(webview, host, port);
+        }
+        // 4.1 or higher (JB)
+        else if (Build.VERSION.SDK_INT <= 18) {
+            return setProxyJBPlus(webview, host, port);
+        }
+        // 4.4 or higher (KK)
+        else if (Build.VERSION.SDK_INT <= 20) {
+            return setKitKatWebViewProxy(context, host, port);
+        }
+        // 5.0 or higher (LP)
+        else {
+            return setLollipopWebViewProxy(context, host, port);
+        }
+    }
+
+    /**
+     * Set Proxy for Android 4.0.3 and above.
+     */
+    @SuppressWarnings("all")
+    private static boolean setProxyICS(WebView webview, String host, int port) {
+        try {
+            Log.d(LOG_TAG, "Setting proxy with 4.0 API.");
+
+            Class jwcjb = Class.forName("android.webkit.JWebCoreJavaBridge");
+            Class params[] = new Class[1];
+            params[0] = Class.forName("android.net.ProxyProperties");
+            Method updateProxyInstance = jwcjb.getDeclaredMethod("updateProxy", params);
+
+            Class wv = Class.forName("android.webkit.WebView");
+            Field mWebViewCoreField = wv.getDeclaredField("mWebViewCore");
+            Object mWebViewCoreFieldInstance = getFieldValueSafely(mWebViewCoreField, webview);
+
+            Class wvc = Class.forName("android.webkit.WebViewCore");
+            Field mBrowserFrameField = wvc.getDeclaredField("mBrowserFrame");
+            Object mBrowserFrame = getFieldValueSafely(mBrowserFrameField, mWebViewCoreFieldInstance);
+
+            Class bf = Class.forName("android.webkit.BrowserFrame");
+            Field sJavaBridgeField = bf.getDeclaredField("sJavaBridge");
+            Object sJavaBridge = getFieldValueSafely(sJavaBridgeField, mBrowserFrame);
+
+            Class ppclass = Class.forName("android.net.ProxyProperties");
+            Class pparams[] = new Class[3];
+            pparams[0] = String.class;
+            pparams[1] = int.class;
+            pparams[2] = String.class;
+            Constructor ppcont = ppclass.getConstructor(pparams);
+
+            updateProxyInstance.invoke(sJavaBridge, ppcont.newInstance(host, port, null));
+
+            Log.d(LOG_TAG, "Setting proxy with 4.0 API successful!");
+            return true;
+        } catch (Exception ex) {
+            Log.e(LOG_TAG, "failed to set HTTP proxy: " + ex);
+            return false;
+        }
+    }
+
+    /**
+     * Set Proxy for Android 4.1 and above.
+     */
+    @SuppressWarnings("all")
+    private static boolean setProxyJBPlus(WebView webview, String host, int port) {
+        Log.d(LOG_TAG, "Setting proxy with >= 4.1 API.");
+
+        try {
+            Class wvcClass = Class.forName("android.webkit.WebViewClassic");
+            Class wvParams[] = new Class[1];
+            wvParams[0] = Class.forName("android.webkit.WebView");
+            Method fromWebView = wvcClass.getDeclaredMethod("fromWebView", wvParams);
+            Object webViewClassic = fromWebView.invoke(null, webview);
+
+            Class wv = Class.forName("android.webkit.WebViewClassic");
+            Field mWebViewCoreField = wv.getDeclaredField("mWebViewCore");
+            Object mWebViewCoreFieldInstance = getFieldValueSafely(mWebViewCoreField, webViewClassic);
+
+            Class wvc = Class.forName("android.webkit.WebViewCore");
+            Field mBrowserFrameField = wvc.getDeclaredField("mBrowserFrame");
+            Object mBrowserFrame = getFieldValueSafely(mBrowserFrameField, mWebViewCoreFieldInstance);
+
+            Class bf = Class.forName("android.webkit.BrowserFrame");
+            Field sJavaBridgeField = bf.getDeclaredField("sJavaBridge");
+            Object sJavaBridge = getFieldValueSafely(sJavaBridgeField, mBrowserFrame);
+
+            Class ppclass = Class.forName("android.net.ProxyProperties");
+            Class pparams[] = new Class[3];
+            pparams[0] = String.class;
+            pparams[1] = int.class;
+            pparams[2] = String.class;
+            Constructor ppcont = ppclass.getConstructor(pparams);
+
+            Class jwcjb = Class.forName("android.webkit.JWebCoreJavaBridge");
+            Class params[] = new Class[1];
+            params[0] = Class.forName("android.net.ProxyProperties");
+            Method updateProxyInstance = jwcjb.getDeclaredMethod("updateProxy", params);
+
+            updateProxyInstance.invoke(sJavaBridge, ppcont.newInstance(host, port, null));
+        } catch (Exception ex) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.1 API failed with error: " + ex.getMessage());
+            return false;
+        }
+
+        Log.d(LOG_TAG, "Setting proxy with >= 4.1 API successful!");
+        return true;
+    }
+
+    /**
+     * Set Proxy for Android 4.4 and above.
+     */
+    @SuppressWarnings("all")
+    private static boolean setKitKatWebViewProxy(Context appContext, String host, int port) {
+        System.setProperty("http.proxyHost", host);
+        System.setProperty("http.proxyPort", port + "");
+        System.setProperty("https.proxyHost", host);
+        System.setProperty("https.proxyPort", port + "");
+        try {
+            Class applictionCls = Class.forName("android.app.Application");
+            Field loadedApkField = applictionCls.getDeclaredField("mLoadedApk");
+            loadedApkField.setAccessible(true);
+            Object loadedApk = loadedApkField.get(appContext);
+            Class loadedApkCls = Class.forName("android.app.LoadedApk");
+            Field receiversField = loadedApkCls.getDeclaredField("mReceivers");
+            receiversField.setAccessible(true);
+            ArrayMap receivers = (ArrayMap) receiversField.get(loadedApk);
+            for (Object receiverMap : receivers.values()) {
+                for (Object rec : ((ArrayMap) receiverMap).keySet()) {
+                    Class clazz = rec.getClass();
+                    if (clazz.getName().contains("ProxyChangeListener")) {
+                        Method onReceiveMethod = clazz.getDeclaredMethod("onReceive", Context.class, Intent.class);
+                        Intent intent = new Intent(Proxy.PROXY_CHANGE_ACTION);
+
+                        /*********** optional, may be need in future *************/
+                        final String CLASS_NAME = "android.net.ProxyProperties";
+                        Class cls = Class.forName(CLASS_NAME);
+                        Constructor constructor = cls.getConstructor(String.class, Integer.TYPE, String.class);
+                        constructor.setAccessible(true);
+                        Object proxyProperties = constructor.newInstance(host, port, null);
+                        intent.putExtra("proxy", (Parcelable) proxyProperties);
+                        /*********** optional, may be need in future *************/
+
+                        onReceiveMethod.invoke(rec, appContext, intent);
+                    }
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (NoSuchFieldException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (IllegalAccessException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (IllegalArgumentException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (NoSuchMethodException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (InvocationTargetException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        } catch (InstantiationException e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 4.4 API failed with error: " + e.getMessage());
+            return false;
+        }
+
+        Log.d(LOG_TAG, "Setting proxy with >= 4.4 API successful!");
+        return true;
+    }
+    /**
+     * Set Proxy for Android 5.0 and above.
+     */
+    @SuppressWarnings("all")
+    private static boolean setLollipopWebViewProxy(Context appContext, String host, int port) {
+        System.setProperty("http.proxyHost", host);
+        System.setProperty("http.proxyPort", port + "");
+        System.setProperty("https.proxyHost", host);
+        System.setProperty("https.proxyPort", port + "");
+        try {
+            Class applictionCls = Class.forName("android.app.Application");
+            Field loadedApkField = applictionCls.getDeclaredField("mLoadedApk");
+            loadedApkField.setAccessible(true);
+            Object loadedApk = loadedApkField.get(appContext);
+            Class loadedApkCls = Class.forName("android.app.LoadedApk");
+            Field receiversField = loadedApkCls.getDeclaredField("mReceivers");
+            receiversField.setAccessible(true);
+            ArrayMap receivers = (ArrayMap) receiversField.get(loadedApk);
+            for (Object receiverMap : receivers.values()) {
+                for (Object rec : ((ArrayMap) receiverMap).keySet()) {
+                    Class clazz = rec.getClass();
+                    if (clazz.getName().contains("ProxyChangeListener")) {
+                        Method onReceiveMethod = clazz.getDeclaredMethod("onReceive", Context.class, Intent.class);
+                        Intent intent = new Intent(Proxy.PROXY_CHANGE_ACTION);
+                        /***** In Lollipop, ProxyProperties went public as ProxyInfo *****/
+                        final String CLASS_NAME = "android.net.ProxyInfo";
+                        Class cls = Class.forName(CLASS_NAME);
+                        /***** ProxyInfo lacks constructors, use the static buildDirectProxy method instead *****/
+                        Method buildDirectProxyMethod = cls.getMethod("buildDirectProxy", String.class, Integer.TYPE);
+                        Object proxyInfo = buildDirectProxyMethod.invoke(cls, host, port);
+                        intent.putExtra("proxy", (Parcelable) proxyInfo);
+                        onReceiveMethod.invoke(rec, appContext, intent);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "Setting proxy with >= 5.0 API failed with " + e.getClass().getName() + ": " + e.getMessage());
+            return false;
+        }
+        Log.d(LOG_TAG, "Setting proxy with >= 5.0 API successful!");
+        return true;
+    }
+
+    private static Object getFieldValueSafely(Field field, Object classInstance) throws IllegalArgumentException,
+            IllegalAccessException {
+        boolean oldAccessibleValue = field.isAccessible();
+        field.setAccessible(true);
+        Object result = field.get(classInstance);
+        field.setAccessible(oldAccessibleValue);
+        return result;
+    }
+
+}

--- a/app/src/main/java/org/indywidualni/fblite/webview/MyWebViewClient.java
+++ b/app/src/main/java/org/indywidualni/fblite/webview/MyWebViewClient.java
@@ -103,7 +103,9 @@ public class MyWebViewClient extends WebViewClient {
                     || Uri.parse(url).getHost().endsWith("akamaihd.net")
                     || Uri.parse(url).getHost().endsWith("ad.doubleclick.net")
                     || Uri.parse(url).getHost().endsWith("sync.liverail.com")
-                    || Uri.parse(url).getHost().endsWith("fb.me")) {
+                    || Uri.parse(url).getHost().endsWith("fb.me")
+                    || Uri.parse(url).getHost().endsWith("facebookcorewwwi.onion")
+                    || Uri.parse(url).getHost().endsWith("fbcdn23dssr3jqnq.onion")) {
                 return false;
             } else if (preferences.getBoolean("load_extra", false)
                     && (Uri.parse(url).getHost().endsWith("googleusercontent.com")

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -115,6 +115,12 @@
             android:defaultValue="false"/>
 
         <SwitchPreference
+            android:key="use_tor"
+            android:title="@string/use_tor_title"
+            android:summary="@string/use_tor_summary"
+            android:defaultValue="false"/>
+
+        <SwitchPreference
             android:key="app_updates"
             android:title="@string/check_for_updates"
             android:defaultValue="true"/>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -115,6 +115,12 @@
             android:defaultValue="false"/>
 
         <CheckBoxPreference
+            android:key="use_tor"
+            android:title="@string/use_tor_title"
+            android:summary="@string/use_tor_summary"
+            android:defaultValue="false"/>
+
+        <CheckBoxPreference
             android:key="app_updates"
             android:title="@string/check_for_updates"
             android:defaultValue="true"/>


### PR DESCRIPTION
I realized that my previous PR for Tor integration was actually not working correctly. So I gave it another try, and this time it definitely works. Part of the implementation is copied from the Tinfoil-Android app.

Tested by blocking FaceSlim connections with AFWall+, and the app was still working via Tor.

Known issue: After disabling Tor in the settings, it will still be used until the app is completely stopped (eg by using the "Terminate" option. But Tinfoil has the same issue.