### PR TITLE
Search view fix

### DIFF
--- a/app/src/main/res/raw/black.css
+++ b/app/src/main/res/raw/black.css
@@ -158,3 +158,11 @@ article h3 {
 .aclb {
     background: #323232 !important;
 }
+
+/* search */
+
+#u_0_33 {
+    background-image: url("data:image/gif;base64,R0lGODlhBAAEAKECABERESQkJP///////yH5BAEKAAIALAAAAAAEAAQAAAIFhB6nhlIAOw==") !important;
+    background-repeat: repeat !important;
+    background-color: #181818 !important;
+}


### PR DESCRIPTION
Fixed transparent background in search view. Tested by debugging Firefox Android (I've changed the useragent to the faceslim default one) with Firefox Linux, so I would test this in faceslim before merging, but it should work.